### PR TITLE
Add text mask helper and mapping docs

### DIFF
--- a/docs/textflow.prompt.md
+++ b/docs/textflow.prompt.md
@@ -1,0 +1,14 @@
+# 📝 textflow.prompt.md – Textkoordinaten aus Canvas
+
+## 🔗 Mapping-Beispiel
+
+```json
+{
+  "text": "System Hero",
+  "size": 64,
+  "font": "Orbitron",
+  "points": [ { "x": 120, "y": 74 }, { "x": 121, "y": 74 }, ... ]
+}
+```
+
+Die Funktion `textToPoints()` aus `src/textMask.ts` verwendet `CanvasRenderingContext2D.getImageData` und liefert diese Punktliste. Sie dient als Eingabe für `ParticlesEngine`.

--- a/src/textMask.ts
+++ b/src/textMask.ts
@@ -1,0 +1,48 @@
+export interface TextMaskOptions {
+  text: string
+  width: number
+  height: number
+  fontSize: number
+  fontFamily?: string
+  step?: number
+}
+
+export interface Point {
+  x: number
+  y: number
+}
+
+export function textToPoints({
+  text,
+  width,
+  height,
+  fontSize,
+  fontFamily = 'sans-serif',
+  step = 2,
+}: TextMaskOptions): Point[] {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return []
+
+  ctx.fillStyle = '#000'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.font = `${fontSize}px ${fontFamily}`
+  ctx.fillText(text, width / 2, height / 2)
+
+  const data = ctx.getImageData(0, 0, width, height).data
+  const points: Point[] = []
+
+  for (let y = 0; y < height; y += step) {
+    for (let x = 0; x < width; x += step) {
+      const idx = (y * width + x) * 4
+      if (data[idx + 3] > 128) {
+        points.push({ x, y })
+      }
+    }
+  }
+
+  return points
+}


### PR DESCRIPTION
## Summary
- add `textToPoints` helper to generate coordinates from canvas text
- document mapping structure in `docs/textflow.prompt.md`

## Testing
- `npm run lint` *(fails: several unused vars and types in docs)*

------
https://chatgpt.com/codex/tasks/task_e_6870ff8ec674832b944bd659e4b8bfe2