### PR TITLE
Fix bounds for high-DPI assemble effect

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -42,8 +42,10 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
 
     const data = offCtx.getImageData(0, 0, offCanvas.width, offCanvas.height).data
     const targets: { x: number; y: number }[] = []
-    for (let y = 0; y < height; y += 2) {
-      for (let x = 0; x < width; x += 2) {
+    const offWidth = Math.floor(offCanvas.width / dpr)
+    const offHeight = Math.floor(offCanvas.height / dpr)
+    for (let y = 0; y < offHeight; y += 2) {
+      for (let x = 0; x < offWidth; x += 2) {
         const idx = ((y * dpr) * offCanvas.width + (x * dpr)) * 4
         if (data[idx + 3] > 128) targets.push({ x, y })
       }

--- a/test/check-dpr.js
+++ b/test/check-dpr.js
@@ -1,0 +1,23 @@
+const width = 800;
+const height = 300;
+const dprs = [0.5, 1, 1.25, 1.5, 2, 2.5, 3];
+
+for (const dpr of dprs) {
+  const offWidth = Math.floor(width * dpr);
+  const offHeight = Math.floor(height * dpr);
+  const dataLength = offWidth * offHeight * 4;
+  const offWidthCSS = Math.floor(offWidth / dpr);
+  const offHeightCSS = Math.floor(offHeight / dpr);
+
+  let maxIdx = 0;
+  for (let y = 0; y < offHeightCSS; y += 2) {
+    for (let x = 0; x < offWidthCSS; x += 2) {
+      const idx = ((y * dpr) * offWidth + (x * dpr)) * 4;
+      if (idx + 3 >= dataLength) {
+        throw new Error(`Index out of bounds for dpr ${dpr} at (${x},${y})`);
+      }
+      if (idx > maxIdx) maxIdx = idx;
+    }
+  }
+  console.log(`dpr ${dpr} - maxIdx ${maxIdx} within ${dataLength}`);
+}


### PR DESCRIPTION
## Summary
- prevent out-of-bounds pixel access in `AssembleTextEffect`
- add a script to verify bounds for multiple `devicePixelRatio` values

## Testing
- `npm run lint`
- `node test/check-dpr.js`

------
https://chatgpt.com/codex/tasks/task_e_68710b3c5370832b8e5b6f8df8e69e6d