### PR TITLE
Fix docs referencing ParticlesEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Background on this idea and current challenges can be found in
 
 The planned modular structure includes:
 
-- `engine/` – particle algorithms (`particles.engine.ts`, `wave.runtime.ts`)
+- `engine/` – particle algorithms (`ParticlesEngine.ts`, `wave.runtime.ts`)
 - `canvas/` – React components running the engine
 - `agents/` – control files such as `canvas.agent.md`
 - `prompts/` – text prompts for generating particle positions

--- a/docs/animation_core.md
+++ b/docs/animation_core.md
@@ -27,7 +27,7 @@ Diese Technik wird **umgedreht**, sodass:
 - Die Funktion `DissipateTextEffect` kann vollständig ignoriert werden und nach unten auf die website gesetzt werden zur referenz.
 - Die Koordinaten stammen weiterhin aus der Canvas-Pixelauswertung
 
-- Die Bewegung soll durch `particles.engine.ts` geregelt werden, nicht durch Timeline-Zerfall für die Lade Animation
+ - Die Bewegung soll durch `ParticlesEngine.ts` geregelt werden, nicht durch Timeline-Zerfall für die Lade Animation
 - Die Partikel **erreichen** statt **verlassen** das Zielbild
 
 ---
@@ -36,7 +36,7 @@ Diese Technik wird **umgedreht**, sodass:
 
 1. [ ] Neue Komponente `AssembleTextEffect.tsx` schreiben (Zielgerichtete Bewegung)
 2. [ ] Alte Zerfallslogik vollständig entfernen (`status == Animate → Dissipate` raus)
-3. [ ] `particles.engine.ts` anpassen, sodass `targetX, targetY` → Fixpunkt ist
+3. [ ] `ParticlesEngine.ts` anpassen, sodass `targetX, targetY` → Fixpunkt ist
 4. [ ] Wellenbasierte Bewegung (`mother_wave`) einbauen → aus `wave.runtime.ts`
 5. [ ] Nur *sichtbare Textpixel* als Zielpunkte verwenden (wie in der Zerfallsversion)
 

--- a/docs/assemble_effect_brief.md
+++ b/docs/assemble_effect_brief.md
@@ -10,7 +10,7 @@ Erzeuge eine sichtbare Animation, bei der **Partikel aus dem Raum** in definiert
 - Canvas-Text wird per `getImageData` in Zielkoordinaten umgewandelt
 - Bewegung basiert nicht auf Zufall, sondern **gerichtet zu Koordinaten**
 - Die Partikel starten aus zufälligen Punkten außerhalb oder innerhalb des Canvas
-- `particles.engine.ts` übernimmt Steuerung
+ - `ParticlesEngine.ts` übernimmt Steuerung (siehe `src/ParticlesEngine.ts`)
 
 ---
 

--- a/docs/codex_animation_prompt.md
+++ b/docs/codex_animation_prompt.md
@@ -34,7 +34,7 @@ TASKS:
 INPUT:
 - `App.tsx` ist der Einstiegspunkt mit mehreren Textsektionen ("System Hero", "IT Services" usw.).
 - Über `ParticleText.tsx` oder das neue `AssembleTextEffect.tsx` muss der Partikeleffekt erfolgen.
-- Wichtige Dateien: `wave.runtime.ts`, `particles.engine.ts`, `scrollTrigger.ts`, `textMask.ts`
+ - Wichtige Dateien: `wave.runtime.ts`, `ParticlesEngine.ts`, `scrollTrigger.ts`, `textMask.ts` (siehe `src/ParticlesEngine.ts`)
 
 OUTPUT:
 - `AssembleTextEffect.tsx` als funktionsfähige Komponente

--- a/docs/codex_project_overview.md
+++ b/docs/codex_project_overview.md
@@ -13,7 +13,7 @@ Das Repository `system-hero-particles` enthält ein mit **Vite** generiertes Rea
 - **React-Komponenten** wie `EmailInput.tsx`, `ParticleText.tsx`
 - **Canvas-Rendering mit GSAP** / ScrollTrigger
 - **Mathematische Runtime**: `wave.runtime.ts`
-- **Partikel-Engine**: `particles.engine.ts`
+ - **Partikel-Engine**: `src/ParticlesEngine.ts`
 - **Agenten-Logik**: `canvas.agent.md`, `wave.controller.agent.md`, `json.rules`
 
 ### 📄 Dokumentiert (konzeptionell)
@@ -85,7 +85,7 @@ Die Bewegung erfolgt über mathematisch gesteuerte Agenten mit Triggern wie `onL
 
 ```bash
 src/
-├── engine/                # particles.engine.ts, wave.runtime.ts
+├── engine/                # ParticlesEngine.ts, wave.runtime.ts
 ├── canvas/                # Canvas-Komponente, useParticlesEngine.ts
 ├── agents/                # canvas.agent.md, wave.controller.agent.md
 ├── prompts/               # textflow.prompt.md, generate_wave.prompt.md

--- a/docs/codex_setup_cli.ts
+++ b/docs/codex_setup_cli.ts
@@ -11,7 +11,7 @@ const FILES = [
   'wave.runtime.ts',
   'canvas.agent.md',
   'canvas.debugOverlay.agent.md',
-  'particles.engine.ts'
+  'ParticlesEngine.ts'
 ]
 
 const CONTENT_MAP: Record<string, string> = {
@@ -22,7 +22,7 @@ const CONTENT_MAP: Record<string, string> = {
   'wave.runtime.ts': '// Siehe wave.runtime.ts Inhalt (via Codex generiert)',
   'canvas.agent.md': '# Siehe canvas.agent.md Inhalt (via Codex generiert)',
   'canvas.debugOverlay.agent.md': '# Siehe canvas.debugOverlay.agent.md Inhalt (via Codex generiert)',
-  'particles.engine.ts': '// Siehe particles.engine.ts Inhalt (via Codex generiert)'
+  'ParticlesEngine.ts': '// Siehe ParticlesEngine.ts Inhalt (via Codex generiert)'
 }
 
 const BASE_PATH = path.resolve(__dirname, 'codex-particles-system')

--- a/docs/particles_engine.ts
+++ b/docs/particles_engine.ts
@@ -1,4 +1,4 @@
-// 🚀 particles.engine.ts – zentrale Steuerlogik für das Partikelsystem
+// 🚀 ParticlesEngine.ts – zentrale Steuerlogik für das Partikelsystem
 
 import { resolveWave, waveFunctions } from './wave.runtime'
 import { getTextTargets } from './textflow.prompt.md'


### PR DESCRIPTION
## Summary
- fix doc references to `ParticlesEngine.ts`
- clarify canonical location `src/ParticlesEngine.ts`

## Testing
- `grep -R "particles.engine.ts" -n docs`

------
https://chatgpt.com/codex/tasks/task_e_68710b3bd078832bac7c2ca3f4eb8664