### PR TITLE
Implement wave-based movement and responsive canvas

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -1,5 +1,6 @@
 // AssembleTextEffect.tsx – Initiale Partikel-Zusammensetzung
 import { useEffect, useRef } from 'react'
+import useMeasure from 'react-use-measure'
 import { ParticlesEngine } from './ParticlesEngine'
 
 interface AssembleTextEffectProps {
@@ -11,15 +12,17 @@ interface AssembleTextEffectProps {
 const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize = 128, color = '#0ff' }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const engineRef = useRef<ParticlesEngine | null>(null)
+  const [containerRef, bounds] = useMeasure()
 
   useEffect(() => {
     const canvas = canvasRef.current
-    if (!canvas) return
+    if (!canvas || !bounds.width || !bounds.height) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
     const dpr = window.devicePixelRatio || 1
-    const { width, height } = canvas
+    const width = bounds.width
+    const height = bounds.height
     canvas.width = width * dpr
     canvas.height = height * dpr
     canvas.style.width = `${width}px`
@@ -51,7 +54,9 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
       }
     }
 
-    const engine = new ParticlesEngine(ctx, width, height, { equationId: 'mother_wave' })
+    const engine = new ParticlesEngine(ctx, width, height, {
+      equationId: 'mother_wave',
+    })
     engine.init(targets)
     engine.run()
     engineRef.current = engine
@@ -59,9 +64,16 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
     return () => {
       engine.stop()
     }
-  }, [text, fontSize, color])
+  }, [text, fontSize, color, bounds.width, bounds.height])
 
-  return <canvas ref={canvasRef} width={800} height={300} />
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+      <canvas
+        ref={canvasRef}
+        style={{ display: 'block', width: '100%', height: '100%' }}
+      />
+    </div>
+  )
 }
 
 export default AssembleTextEffect

--- a/src/ParticlesEngine.ts
+++ b/src/ParticlesEngine.ts
@@ -53,20 +53,25 @@ export class ParticlesEngine {
   update(dt: number) {
     this.time += dt
     for (const p of this.particles) {
-      const fx = this.equation(p.x, p.y, this.time, this.params)
+      const fx = this.equation(p.x, p.y, this.time, {
+        ...this.params,
+        x0: p.targetX,
+        y0: p.targetY,
+      })
+
       if (typeof fx === 'number') {
-        const dx = p.targetX - p.x
-        const dy = p.targetY - p.y
-        p.x += dx * 0.08
-        p.y += dy * 0.08
-        p.vx *= 0.9
-        p.vy *= 0.9
+        const angle = Math.atan2(p.targetY - p.y, p.targetX - p.x)
+        p.vx += Math.cos(angle) * fx
+        p.vy += Math.sin(angle) * fx
       } else {
-        p.vx = fx.vx
-        p.vy = fx.vy
-        p.x += p.vx
-        p.y += p.vy
+        p.vx += fx.vx
+        p.vy += fx.vy
       }
+
+      p.vx *= 0.9
+      p.vy *= 0.9
+      p.x += p.vx
+      p.y += p.vy
     }
   }
 

--- a/src/create-particles-demo.ts
+++ b/src/create-particles-demo.ts
@@ -1,4 +1,5 @@
-import { writeFileSync } from 'fs';
+// @ts-expect-error -- demo script, Node types not included
+import { writeFileSync } from 'node:fs'
 
 const files = {
   'src/ParticleText.tsx': `// <-- pack hier deinen ParticleText Code rein`,

--- a/src/wave.runtime.ts
+++ b/src/wave.runtime.ts
@@ -52,16 +52,32 @@ export const waveFunctions = {
     y: number,
     t: number,
     params: WaveParams,
-  ): number => {
-    const { A = 1.0, k = 0.1, omega = 2.0, alpha = 0.05, gamma = 3.0, epsilon = 0.1, x0 = 0, y0 = 0 } = params
+  ): { vx: number; vy: number } => {
+    const {
+      A = 1.0,
+      k = 0.1,
+      omega = 2.0,
+      alpha = 0.05,
+      gamma = 3.0,
+      epsilon = 0.1,
+      x0 = 0,
+      y0 = 0,
+    } = params
     const dx = x - x0
     const dy = y - y0
-    const r = Math.hypot(dx, dy)
+    const r = Math.hypot(dx, dy) || 1
     const wave = A * Math.sin(k * r - omega * t)
     const gravity = gamma / (r ** 2 + epsilon)
-    return (wave + gravity) * Math.exp(-alpha * t)
+    const magnitude = (wave + gravity) * Math.exp(-alpha * t)
+    const angle = Math.atan2(dy, dx)
+    return { vx: -Math.cos(angle) * magnitude, vy: -Math.sin(angle) * magnitude }
   }
 }
-export const resolveWave = (id: string) => {
-  return waveFunctions[id] || waveFunctions['mother_wave']
+export const resolveWave = (
+  id: keyof typeof waveFunctions | string,
+) => {
+  return (
+    waveFunctions[id as keyof typeof waveFunctions] ||
+    waveFunctions['mother_wave']
+  )
 }


### PR DESCRIPTION
## Summary
- add responsive canvas with `useMeasure`
- implement wave-based velocity calculation in `ParticlesEngine`
- update `mother_wave` to output velocity
- fix TypeScript build issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871106ba698832b8ffef46b5074b2e6