### PR TITLE
Fix font loading in hero particle animation

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -15,10 +15,16 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
   const [containerRef, bounds] = useMeasure()
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas || !bounds.width || !bounds.height) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
+    let cancelled = false
+
+    const start = async () => {
+      await (document as any).fonts?.ready
+      if (cancelled) return
+
+      const canvas = canvasRef.current
+      if (!canvas || !bounds.width || !bounds.height) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
 
     const dpr = window.devicePixelRatio || 1
     const width = bounds.width
@@ -61,8 +67,13 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
     engine.run()
     engineRef.current = engine
 
+    }
+
+    start()
+
     return () => {
-      engine.stop()
+      cancelled = true
+      engineRef.current?.stop()
     }
   }, [text, fontSize, color, bounds.width, bounds.height])
 


### PR DESCRIPTION
## Summary
- wait for fonts to finish loading before starting `AssembleTextEffect`

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871168f56f4832bb8c58e65e50f755b