### PR TITLE
Start hero animation on intersection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,31 @@
 import ParticleText from './ParticleText'
 import EmailInput from './EmailInput'
 import AssembleTextEffect from './AssembleTextEffect'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export default function App() {
   const [startHero, setStartHero] = useState(false)
+  const heroRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    setStartHero(true)
+    const el = heroRef.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setStartHero(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    observer.observe(el)
+
+    return () => {
+      observer.disconnect()
+    }
   }, [])
 
   return (
@@ -22,6 +40,7 @@ export default function App() {
     >
       {/* Hero Section mit AssembleTextEffect */}
       <section
+        ref={heroRef}
         style={{
           height: '100vh',
           display: 'flex',


### PR DESCRIPTION
## Summary
- start `AssembleTextEffect` only when hero section is visible
- disconnect `IntersectionObserver` on cleanup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68713ce253dc832b9609fa1cef636aa4