### PR TITLE
Remove IntersectionObserver from hero

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,8 @@
 import ParticleText from './ParticleText'
 import EmailInput from './EmailInput'
 import AssembleTextEffect from './AssembleTextEffect'
-import { useEffect, useRef, useState } from 'react'
 
 export default function App() {
-  const [startHero, setStartHero] = useState(false)
-  const heroRef = useRef<HTMLElement | null>(null)
-
-  useEffect(() => {
-    const el = heroRef.current
-    if (!el) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setStartHero(true)
-          observer.disconnect()
-        }
-      },
-      { threshold: 0.1 }
-    )
-
-    observer.observe(el)
-
-    return () => {
-      observer.disconnect()
-    }
-  }, [])
 
   return (
     <div
@@ -40,7 +16,6 @@ export default function App() {
     >
       {/* Hero Section mit AssembleTextEffect */}
       <section
-        ref={heroRef}
         style={{
           height: '100vh',
           display: 'flex',
@@ -49,7 +24,7 @@ export default function App() {
           fontSize: '2rem',
         }}
       >
-        {startHero && <AssembleTextEffect text="System Hero" />}
+        <AssembleTextEffect text="System Hero" />
       </section>
 
       {/* ParticleText Sections */}


### PR DESCRIPTION
## Summary
- delete scroll-triggered hero logic
- always render `AssembleTextEffect` in hero section

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687176ca0050832b98ab1de66529c70a