### PR TITLE
Update ParticlesEngine timing

### DIFF
--- a/src/ParticlesEngine.ts
+++ b/src/ParticlesEngine.ts
@@ -85,7 +85,7 @@ export class ParticlesEngine {
     })
   }
 
-  update(dt: number) {
+  update(dt = 0.016) {
     this.time += dt
     for (const p of this.particles) {
       const fx = this.equation(p.x, p.y, this.time, {
@@ -121,8 +121,11 @@ export class ParticlesEngine {
   }
 
   run() {
-    const loop = () => {
-      this.update(0.016)
+    let lastTime: number | null = null
+    const loop = (timestamp: number) => {
+      const dt = lastTime === null ? 0.016 : (timestamp - lastTime) / 1000
+      lastTime = timestamp
+      this.update(dt)
       this.draw()
       this.rafId = requestAnimationFrame(loop)
     }


### PR DESCRIPTION
## Summary
- compute `dt` from `requestAnimationFrame` timestamps
- default `update()` to 60 FPS when timestamps unavailable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687185f3d3c8832b8e96fa541501ab9a