### PR TITLE
Fix mother_wave return type

### DIFF
--- a/docs/math_map.md
+++ b/docs/math_map.md
@@ -90,7 +90,7 @@ def mother_wave(x, y, t, A=1.0, k=0.1, omega=2.0, alpha=0.05, gamma=3.0, epsilon
     r = math.sqrt(dx**2 + dy**2)
     wave = A * math.sin(k * r - omega * t)
     gravity = gamma / (r**2 + epsilon)
-    return (wave + gravity) * math.exp(-alpha * t)
+    return (wave + gravity) * math.exp(-alpha * t)  # scalar amplitude
 ```
 
 ---

--- a/src/wave.runtime.ts
+++ b/src/wave.runtime.ts
@@ -52,7 +52,7 @@ export const waveFunctions = {
     y: number,
     t: number,
     params: WaveParams,
-  ): { vx: number; vy: number } => {
+  ): number => {
     const {
       A = 1.0,
       k = 0.1,
@@ -65,12 +65,10 @@ export const waveFunctions = {
     } = params
     const dx = x - x0
     const dy = y - y0
-    const r = Math.hypot(dx, dy) || 1
+    const r = Math.hypot(dx, dy)
     const wave = A * Math.sin(k * r - omega * t)
     const gravity = gamma / (r ** 2 + epsilon)
-    const magnitude = (wave + gravity) * Math.exp(-alpha * t)
-    const angle = Math.atan2(dy, dx)
-    return { vx: -Math.cos(angle) * magnitude, vy: -Math.sin(angle) * magnitude }
+    return (wave + gravity) * Math.exp(-alpha * t)
   }
 }
 export const resolveWave = (


### PR DESCRIPTION
## Summary
- make mother_wave return a scalar like docs
- note scalar amplitude in math_map documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871951d09a8832ba3abe8e26eb527f6