### PR TITLE
Add text reveal on particle completion

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -1,5 +1,5 @@
 // AssembleTextEffect.tsx – Initiale Partikel-Zusammensetzung
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useMeasure from 'react-use-measure'
 import { ParticlesEngine } from './ParticlesEngine'
 
@@ -13,9 +13,11 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const engineRef = useRef<ParticlesEngine | null>(null)
   const [containerRef, bounds] = useMeasure()
+  const [showText, setShowText] = useState(false)
 
   useEffect(() => {
     let cancelled = false
+    setShowText(false)
 
     const start = async () => {
       await document.fonts?.ready
@@ -66,7 +68,7 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
       equationId: 'mother_wave',
     })
     engine.init(targets)
-    engine.run()
+    engine.run(() => setShowText(true))
     engineRef.current = engine
 
     }
@@ -104,6 +106,8 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
           color,
           textAlign: 'center',
           whiteSpace: 'nowrap',
+          opacity: showText ? 1 : 0,
+          transition: 'opacity 0.4s ease',
         }}
       >
         {text}

--- a/src/ParticlesEngine.ts
+++ b/src/ParticlesEngine.ts
@@ -130,13 +130,20 @@ export class ParticlesEngine {
     }
   }
 
-  run() {
+  run(onComplete?: () => void) {
     this.lastTime = null
     const loop = (timestamp: number) => {
       const dt = this.lastTime === null ? 0.016 : (timestamp - this.lastTime) / 1000
       this.lastTime = timestamp
       this.update(dt)
       this.draw()
+      const done = this.particles.every(
+        p => p.x === p.targetX && p.y === p.targetY
+      )
+      if (done) {
+        onComplete?.()
+        return
+      }
       this.rafId = requestAnimationFrame(loop)
     }
     this.rafId = requestAnimationFrame(loop)


### PR DESCRIPTION
## Summary
- add a `showText` state to `AssembleTextEffect`
- expose `onComplete` callback for `ParticlesEngine.run`
- reveal the text after particles finish assembling

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687197e23e0c832b8f51708458719d09