### PR TITLE
Implement completion callback

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -64,11 +64,17 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
       }
     }
 
-    const engine = new ParticlesEngine(ctx, width, height, {
-      equationId: 'mother_wave',
-    })
+    const engine = new ParticlesEngine(
+      ctx,
+      width,
+      height,
+      {
+        equationId: 'mother_wave',
+      },
+      () => setShowText(true)
+    )
     engine.init(targets)
-    engine.run(() => setShowText(true))
+    engine.run()
     engineRef.current = engine
 
     }
@@ -86,15 +92,17 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
       ref={containerRef}
       style={{ position: 'relative', width: '100%', height: '100%' }}
     >
-      <canvas
-        ref={canvasRef}
-        style={{
-          position: 'absolute',
-          inset: 0,
-          width: '100%',
-          height: '100%',
-        }}
-      />
+      {!showText && (
+        <canvas
+          ref={canvasRef}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+          }}
+        />
+      )}
       <span
         style={{
           position: 'absolute',


### PR DESCRIPTION
## Summary
- allow `ParticlesEngine` to accept an `onComplete` callback via constructor
- stop the engine when every particle reaches its target
- use the callback in `AssembleTextEffect` and remove the canvas when done

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68719929e35c832bb4c36f43b80410c4