### PR TITLE
Fix stopping of particle engine

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -83,7 +83,10 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
 
     return () => {
       cancelled = true
-      engineRef.current?.stop()
+      if (engineRef.current) {
+        engineRef.current.stop()
+        engineRef.current = null
+      }
     }
   }, [text, fontSize, color, bounds.width, bounds.height])
 

--- a/src/ParticlesEngine.ts
+++ b/src/ParticlesEngine.ts
@@ -157,8 +157,8 @@ export class ParticlesEngine {
       const dt = this.lastTime === null ? 0.016 : (timestamp - this.lastTime) / 1000
       this.lastTime = timestamp
       this.update(dt)
-      this.draw()
       if (!this.running) return
+      this.draw()
       this.rafId = requestAnimationFrame(loop)
     }
     this.rafId = requestAnimationFrame(loop)
@@ -167,6 +167,7 @@ export class ParticlesEngine {
   stop() {
     this.running = false
     cancelAnimationFrame(this.rafId)
+    this.rafId = 0
     this.lastTime = null
   }
 }


### PR DESCRIPTION
## Summary
- ensure ParticleEngine stops drawing when requested
- stop the engine and clear ref on AssembleTextEffect cleanup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68719b253070832baafcae7d0ee3dccc