### PR TITLE
Fix DPR pixel sampling

### DIFF
--- a/src/AssembleTextEffect.tsx
+++ b/src/AssembleTextEffect.tsx
@@ -53,14 +53,11 @@ const AssembleTextEffect: React.FC<AssembleTextEffectProps> = ({ text, fontSize 
 
     const data = offCtx.getImageData(0, 0, offCanvas.width, offCanvas.height).data
     const targets: { x: number; y: number }[] = []
-    const offWidth = Math.floor(offCanvas.width / dpr)
-    const offHeight = Math.floor(offCanvas.height / dpr)
-    for (let y = 0; y < offHeight; y += 2) {
-      for (let x = 0; x < offWidth; x += 2) {
-        const iy = Math.floor(y * dpr)
-        const ix = Math.floor(x * dpr)
-        const idx = (iy * offCanvas.width + ix) * 4
-        if (data[idx + 3] > 128) targets.push({ x, y })
+    const step = Math.max(1, Math.round(dpr))
+    for (let y = 0; y < offCanvas.height; y += step) {
+      for (let x = 0; x < offCanvas.width; x += step) {
+        const idx = (y * offCanvas.width + x) * 4
+        if (data[idx + 3] > 128) targets.push({ x: x / dpr, y: y / dpr })
       }
     }
 

--- a/src/ParticleText.tsx
+++ b/src/ParticleText.tsx
@@ -65,18 +65,17 @@ const ParticleText: React.FC<Props> = ({
 
     // Neue Partikel erzeugen
     particles.current = []
-    for (let y = 0; y < height; y += 3) {
-      for (let x = 0; x < width; x += 3) {
-        const iy = Math.floor(y * dpr)
-        const ix = Math.floor(x * dpr)
-        const index = (iy * offCanvas.width + ix) * 4
-        const alpha = imageData[index + 3]
+    const step = Math.max(1, Math.round(dpr))
+    for (let y = 0; y < offCanvas.height; y += step) {
+      for (let x = 0; x < offCanvas.width; x += step) {
+        const idx = (y * offCanvas.width + x) * 4
+        const alpha = imageData[idx + 3]
         if (alpha > 128 && Math.random() < density) {
           particles.current.push({
             x: Math.random() * width,
             y: Math.random() * height,
-            tx: x,
-            ty: y,
+            tx: x / dpr,
+            ty: y / dpr,
             vx: 0,
             vy: 0,
           })


### PR DESCRIPTION
## Summary
- iterate over offscreen canvas using full resolution
- sample pixels in `AssembleTextEffect` and `ParticleText` based on device pixel ratio
- convert target coordinates back to CSS pixels

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68719b2f1414832b854642879be211cd