### PR TITLE
Wrap ParticleIntro with fixed height container

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ System Hero Particles zeigt, wie Text per Partikel sichtbar gemacht und anschlie
 - 2025-07-19: Tailwind-Konfiguration hinzugefuegt und main.tsx eingerichtet.
 - 2025-07-20: ParticleIntro-Komponente erstellt und App.tsx angepasst.
 - 2025-07-21: Messfunktionen hinzugefuegt und Offsets zur absoluten Positionierung verwendet.
+- 2025-07-22: App.tsx Wrapper fuer ParticleIntro mit fester Hoehe hinzugefuegt.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,13 @@ import { ParticleIntro } from './components/ParticleIntro'; // Intro-Komponente 
 export default function App() {
   return (
     <div className="h-screen w-full flex items-center justify-center bg-black text-white"> {/* Vollbild-Hintergrund */}
-      <ParticleIntro
-        text="HELLO WORLD" // Beispieltext
-        font="700 80px Orbitron, sans-serif" // Einheitliche Schriftdefinition
-        padding={80} // Innenabstand des Canvas
-      />
+      <div className="relative w-full h-[160px]"> {/* Fester Wrapper gemaess Setup */}
+        <ParticleIntro
+          text="HELLO WORLD" // Beispieltext
+          font="700 80px Orbitron, sans-serif" // Einheitliche Schriftdefinition
+          padding={80} // Innenabstand des Canvas
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `ParticleIntro` in `App.tsx` using a `h-[160px]` container per setup rules
- log the update in `README.md`

## Testing
- `npm run dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687be87da8b0832bbe27049af11b01bc