### PR TITLE
Add devicePixelRatio scaling for Canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ System Hero Particles zeigt, wie Text per Partikel sichtbar gemacht und anschlie
 - 2025-07-21: Messfunktionen hinzugefuegt und Offsets zur absoluten Positionierung verwendet.
 - 2025-07-22: App.tsx Wrapper fuer ParticleIntro mit fester Hoehe hinzugefuegt.
 - 2025-07-23: Letter-Spacing korrekt vermessen und Offsets auf Zoom vorbereitet.
+- 2025-07-24: Canvas-Dimensionen mit devicePixelRatio skaliert und DPR-Ausgabe in
+  ParticleIntro integriert.


### PR DESCRIPTION
## Summary
- use `getPixelRatio` in AssembleEffect and fade canvas
- multiply canvas internal dimensions with DPR and scale context
- keep CSS width/height for layout
- update README logbook

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bee649bfc832bbe176806885b8db9