### PR TITLE
Fix goal documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ System Hero Particles zeigt, wie Text per Partikel sichtbar gemacht und anschlie
 - 2025-07-24: Canvas-Dimensionen mit devicePixelRatio skaliert und DPR-Ausgabe in
   ParticleIntro integriert.
 - 2025-07-25: ToDo-Liste erstellt, um Aufgaben zur perfekten Ueberlagerung von H1 und Canvas zu sammeln.
+- 2025-07-26: Dokumentationspfad fuer goal.md korrigiert und fehlende Datei docs/codex/goal.md angelegt.

--- a/docs/codex/goal.md
+++ b/docs/codex/goal.md
@@ -1,0 +1,6 @@
+# System Hero Particle Animation Goal
+
+This document outlines the vision for the particle animation used throughout the System Hero project.
+
+The aim is to render each letter as particles on a canvas and transition them seamlessly into selectable DOM text. Absolute positions are calculated so that canvas and text overlap perfectly on any display or zoom level.
+

--- a/goal.md
+++ b/goal.md
@@ -1,3 +1,3 @@
 # Project Goal
 
-For the full description of the System Hero particle animation goal, see [docs/codex/goal.md](../docs/codex/goal.md).
+For the full description of the System Hero particle animation goal, see [docs/codex/goal.md](docs/codex/goal.md).


### PR DESCRIPTION
## Summary
- create `docs/codex/goal.md` with project description
- fix link in `goal.md` to point to new docs path
- add entry in README logbook

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bf4fa9e54832bb351a752a90378d1