### PR TITLE
Wait for fonts before measuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ System Hero Particles zeigt, wie Text per Partikel sichtbar gemacht und anschlie
   ParticleIntro integriert.
 - 2025-07-25: ToDo-Liste erstellt, um Aufgaben zur perfekten Ueberlagerung von H1 und Canvas zu sammeln.
 - 2025-07-26: Dokumentationspfad fuer goal.md korrigiert und fehlende Datei docs/codex/goal.md angelegt.
+- 2025-07-27: Fonts werden nun via document.fonts.ready abgewartet, bevor ParticleIntro die Messung startet.
+- 2025-07-28: document.fonts.ready mit Fallback eingebaut, Messung startet erst nach Schriftladen.

--- a/src/components/ParticleIntro.tsx
+++ b/src/components/ParticleIntro.tsx
@@ -155,9 +155,19 @@ export const ParticleIntro: React.FC<ParticleIntroProps> = ({
   const [phase, setPhase] = useState<'preparing' | 'animating' | 'fading'>('preparing'); // aktueller Ablaufstatus
   const headlineRef = useRef<HTMLHeadingElement | null>(null); // Referenz auf das H1 Element
   const dpr = getPixelRatio(); // Aktuelle Device Pixel Ratio
+  const [fontsReady, setFontsReady] = useState(false); // Schriftlade-Status
+
+  // Warten bis die benutzten Webfonts geladen sind
+  useEffect(() => {
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => setFontsReady(true));
+    } else {
+      setFontsReady(true); // Fallback fuer Browser ohne Font Loading API
+    }
+  }, []);
 
   useLayoutEffect(() => { // Nach Layout wird die Groesse gemessen
-    if (headlineRef.current && phase === 'preparing') {
+    if (headlineRef.current && phase === 'preparing' && fontsReady) {
       const r = measureElementRect(headlineRef.current); // DOM-Box abfragen
       const spacing = getLetterSpacing(headlineRef.current); // Letter-Spacing lesen
       const metrics = measureTextMetrics(font, text, spacing); // Glyphenbox messen
@@ -166,7 +176,7 @@ export const ParticleIntro: React.FC<ParticleIntroProps> = ({
       setOffsets(offs);
       saveOffsets('particleOffsets', offs); // optional speichern
     }
-  }, [phase, font, text]);
+  }, [phase, font, text, fontsReady]);
 
   useEffect(() => {
     const saved = loadOffsets('particleOffsets'); // gespeicherte Werte abrufen


### PR DESCRIPTION
## Summary
- add font loading fallback in `ParticleIntro`
- document the change in the README logbook

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bfa6e2ac8832bb7cdcd8b87075fff